### PR TITLE
chore: disable v-bind-order-sensitive transformation for -a

### DIFF
--- a/bin/vue-codemod.ts
+++ b/bin/vue-codemod.ts
@@ -12,6 +12,7 @@ import createDebug from 'debug'
 import builtInTransformations from '../transformations'
 import { excludedTransformations } from '../transformations'
 import vueTransformations from '../vue-transformations'
+import { excludedVueTransformations } from '../vue-transformations'
 import runTransformation from '../src/runTransformation'
 import { transform as packageTransform } from '../src/packageTransformation'
 
@@ -77,7 +78,9 @@ async function main() {
     }
 
     for (let key in vueTransformations) {
-      processTransformation(resolvedPaths, key, vueTransformations[key])
+      if (!excludedVueTransformations.includes(key)) {
+        processTransformation(resolvedPaths, key, vueTransformations[key])
+      }
     }
     packageTransform()
   }

--- a/vue-transformations/index.ts
+++ b/vue-transformations/index.ts
@@ -18,4 +18,8 @@ const transformationMap: {
   'remove-listeners': require('./remove-listeners')
 }
 
+export const excludedVueTransformations = [
+  'v-bind-order-sensitive'
+]
+
 export default transformationMap


### PR DESCRIPTION
currently `v-bind-order-sensitive` transformation is not perfect, so disable it for `-a` command