### PR TITLE
feat: implement .sync modifiers in v-bind to v-model transformation

### DIFF
--- a/src/operationUtils.ts
+++ b/src/operationUtils.ts
@@ -128,3 +128,15 @@ export function removeRange(range: number[]): Operation {
     text: ''
   }
 }
+
+/**
+ * Get text of Node
+ * @param {Node} node The node to get text
+ * @param {string} source The full text of the source code
+ * @returns {string} The text of the node
+ */
+export function getText(node: Node, source: string): string {
+  const start = node.range[0]
+  const end = node.range[1]
+  return source.slice(start, end)
+}

--- a/vue-transformations/__test__/v-bind-sync.spec.ts
+++ b/vue-transformations/__test__/v-bind-sync.spec.ts
@@ -1,0 +1,9 @@
+import { runTest } from '../../src/testUtils'
+
+runTest(
+  'Convert usage of slot-scope before vue 2.6',
+  'v-bind-sync',
+  'v-bind-sync',
+  'vue',
+  'vue'
+)

--- a/vue-transformations/__testfixtures__/v-bind-sync/v-bind-sync.input.vue
+++ b/vue-transformations/__testfixtures__/v-bind-sync/v-bind-sync.input.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="hello">
+    <ChildComponent :title.sync="pageTitle" />
+  </div>
+</template>

--- a/vue-transformations/__testfixtures__/v-bind-sync/v-bind-sync.output.vue
+++ b/vue-transformations/__testfixtures__/v-bind-sync/v-bind-sync.output.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="hello">
+    <ChildComponent v-model:title="pageTitle" />
+  </div>
+</template>

--- a/vue-transformations/index.ts
+++ b/vue-transformations/index.ts
@@ -15,7 +15,8 @@ const transformationMap: {
   'transition-group-root': require('./transition-group-root'),
   'v-bind-order-sensitive': require('./v-bind-order-sensitive'),
   'v-for-v-if-precedence-changed': require('./v-for-v-if-precedence-changed'),
-  'remove-listeners': require('./remove-listeners')
+  'remove-listeners': require('./remove-listeners'),
+  'v-bind-sync': require('./v-bind-sync')
 }
 
 export const excludedVueTransformations = ['v-bind-order-sensitive']

--- a/vue-transformations/v-bind-sync.ts
+++ b/vue-transformations/v-bind-sync.ts
@@ -7,9 +7,9 @@ import wrap from '../src/wrapVueTransformation'
 
 export const transformAST: VueASTTransformation = context => {
   let fixOperations: Operation[] = []
-  const toFixNodes: Node[] = findNodes(context)
   const { file } = context
   const source = file.source
+  const toFixNodes: Node[] = findNodes(context)
   toFixNodes.forEach(node => {
     fixOperations = fixOperations.concat(fix(node, source))
   })
@@ -35,7 +35,7 @@ function findNodes(context: any): Node[] {
       if (
         node.type === 'VAttribute' &&
         node.directive &&
-        node.key.name.name === 'slot-scope'
+        node.key.name.name === 'bind'
       ) {
         toFixNodes.push(node)
       }
@@ -50,13 +50,17 @@ function findNodes(context: any): Node[] {
  */
 function fix(node: Node, source: string): Operation[] {
   let fixOperations: Operation[] = []
-  const element: any = node!.parent!.parent
   // @ts-ignore
-  const scopeValue: string = OperationUtils.getText(node.value, source)
+  const keyNode = node.key
+  const argument = keyNode.argument
+  const modifiers = keyNode.modifiers
+  const bindArgument = OperationUtils.getText(argument, source)
 
-  if (!!element && element.type == 'VElement' && element.name == 'template') {
-    // template element replace slot-scope="xxx" to v-slot="xxx"
-    fixOperations.push(OperationUtils.replaceText(node, `v-slot=${scopeValue}`))
+  if (argument !== null && modifiers.length === 1) {
+    // .sync modifiers in v-bind should be replaced with v-model
+    fixOperations.push(
+      OperationUtils.replaceText(keyNode, `v-model:${bindArgument}`)
+    )
   }
 
   return fixOperations

--- a/vue-transformations/v-bind-sync.ts
+++ b/vue-transformations/v-bind-sync.ts
@@ -56,7 +56,11 @@ function fix(node: Node, source: string): Operation[] {
   const modifiers = keyNode.modifiers
   const bindArgument = OperationUtils.getText(argument, source)
 
-  if (argument !== null && modifiers.length === 1) {
+  if (
+    argument !== null &&
+    modifiers.length === 1 &&
+    modifiers[0].name === 'sync'
+  ) {
     // .sync modifiers in v-bind should be replaced with v-model
     fixOperations.push(
       OperationUtils.replaceText(keyNode, `v-model:${bindArgument}`)


### PR DESCRIPTION
in Vue 3, `v-bind`'s `.sync` modifier and component `model` option are removed and replaced with an argument on `v-model`:

```
<ChildComponent :title.sync="pageTitle" />

<!-- to be replaced with -->

<ChildComponent v-model:title="pageTitle" />
```