### PR TITLE
fix: render funciton expression can't be transformed

### DIFF
--- a/transformations/__tests__/remove-contextual-h-from-render.spec.ts
+++ b/transformations/__tests__/remove-contextual-h-from-render.spec.ts
@@ -12,6 +12,14 @@ defineInlineTest(
 defineInlineTest(
   transform,
   {},
+  `export default { render: function(h) { return h("div", ["hello"]) } };`,
+  `import { h } from "vue";\nexport default { render: function() { return h("div", ["hello"]) } };`,
+  'remove h from arrow functions'
+)
+
+defineInlineTest(
+  transform,
+  {},
   `export default { render(h) { return h("div", ["hello"]); } };`,
   `import { h } from "vue";\nexport default { render() { return h("div", ["hello"]); } };`,
   'remove h from object methods'

--- a/transformations/remove-contextual-h-from-render.ts
+++ b/transformations/remove-contextual-h-from-render.ts
@@ -7,13 +7,12 @@ import { transformAST as addImport } from './add-import'
 
 export const transformAST: ASTTransformation = context => {
   const { root, j } = context
-  const renderFns = root.find(j.ObjectProperty, {
-    key: {
-      name: 'render'
-    },
-    value: {
-      type: 'ArrowFunctionExpression'
-    }
+  const renderFns = root.find(j.ObjectProperty, n => {
+    return (
+      n.key.name === 'render' &&
+      (n.value.type === 'ArrowFunctionExpression' ||
+        n.value.type === 'FunctionExpression')
+    )
   })
 
   const renderMethods = root.find(j.ObjectMethod, {


### PR DESCRIPTION
when type of render function is `FunctionExpression` , it also should be transformed.
```vue
import Vue from "vue"
import App from "./App.vue"

new Vue({
  render: function(h) {
    return h(App)
  }
}).mount("#app")
```

should be transformed to:

```vue
import * as Vue from "vue";
import App from "./App.vue"

import { h } from "vue";

Vue.createApp({
  render: function() {
    return h(App)
  }
}).mount("#app")
```