### PR TITLE
feat: root i18n prop to use

### DIFF
--- a/transformations/new-global-api.ts
+++ b/transformations/new-global-api.ts
@@ -18,6 +18,7 @@ export const transformAST: ASTTransformation = context => {
   newVueTocreateApp(context)
   rootPropToUse(context, { rootPropName: 'store' })
   rootPropToUse(context, { rootPropName: 'router' })
+  rootPropToUse(context, { rootPropName: 'i18n' })
   removeTrivialRoot(context)
   removeProductionTip(context)
 


### PR DESCRIPTION
transform `i18n` root prop to `app.use`:
```
new Vue({
  i18n,
  render: h => h(App),
}).$mount('#app')
```
=> 
```
Vue.createApp(App).use(i18n).mount('#app')
```