### PR TITLE
feat: remove the fallback property

### DIFF
--- a/transformations/__testfixtures__/vue-router-v4/create-router.input.js
+++ b/transformations/__testfixtures__/vue-router-v4/create-router.input.js
@@ -20,7 +20,8 @@ const router = new VueRouter({
 });
 
 new VueRouter({
-  routes
+  routes,
+  fallback: false
 });
 
 export default router;

--- a/transformations/vue-router-v4.ts
+++ b/transformations/vue-router-v4.ts
@@ -64,6 +64,8 @@ export const transformAST: ASTTransformation = context => {
         } else if ((p.key as any).name === 'base') {
           baseValue = p.value
           return false
+        } else if ((p.key as any).name === 'fallback') {
+          return false
         }
 
         return true


### PR DESCRIPTION
The fallback option is no longer supported when creating the router:
```js
-new VueRouter({
+createRouter({
-  fallback: false,
// other options...
})
```