### PR TITLE
fix: createLogger function name not to be transformed

### DIFF
--- a/transformations/__tests__/vuex-create-logger.spec.ts
+++ b/transformations/__tests__/vuex-create-logger.spec.ts
@@ -14,3 +14,17 @@ const store = new Vuex.Store({
 })`,
   'vuex createLogger'
 )
+
+defineInlineTest(
+  transform,
+  {},
+  `import logger from 'vuex/dist/logger'
+const store = new Vuex.Store({
+  plugins: [logger()]
+})`,
+  `import { createLogger } from "vuex";
+const store = new Vuex.Store({
+  plugins: [createLogger()]
+})`,
+  'vuex createLogger another name'
+)

--- a/transformations/vuex-create-logger.ts
+++ b/transformations/vuex-create-logger.ts
@@ -5,11 +5,23 @@ export const transformAST: ASTTransformation = ({ root, j }) => {
   //  find the import xxx from 'vuex/dist/logger'
   const importDeclarationCollection = root.find(j.ImportDeclaration, node => {
     return (
+      node.specifiers.length === 1 &&
       node.specifiers[0].type === 'ImportDefaultSpecifier' &&
       node.source.value === 'vuex/dist/logger'
     )
   })
   if (!importDeclarationCollection.length) return
+
+  const importName = importDeclarationCollection.get(0).node.specifiers[0].local.name
+  if (importName !== 'createLogger') {
+    //  rename function name
+    root.find(j.CallExpression, node => {
+      return node.callee.name === importName
+    }).replaceWith(({ node }) => {
+      // @ts-ignore
+      return j.callExpression(j.identifier('createLogger'), node.arguments)
+    })
+  }
 
   //  remove import
   importDeclarationCollection.remove()

--- a/transformations/vuex-create-logger.ts
+++ b/transformations/vuex-create-logger.ts
@@ -12,15 +12,18 @@ export const transformAST: ASTTransformation = ({ root, j }) => {
   })
   if (!importDeclarationCollection.length) return
 
-  const importName = importDeclarationCollection.get(0).node.specifiers[0].local.name
+  const importName =
+    importDeclarationCollection.get(0).node.specifiers[0].local.name
   if (importName !== 'createLogger') {
     //  rename function name
-    root.find(j.CallExpression, node => {
-      return node.callee.name === importName
-    }).replaceWith(({ node }) => {
-      // @ts-ignore
-      return j.callExpression(j.identifier('createLogger'), node.arguments)
-    })
+    root
+      .find(j.CallExpression, node => {
+        return node.callee.name === importName
+      })
+      .replaceWith(({ node }) => {
+        // @ts-ignore
+        return j.callExpression(j.identifier('createLogger'), node.arguments)
+      })
   }
 
   //  remove import


### PR DESCRIPTION
fix createLogger function name not to be transformed
linked issue : #50 
```
import logger from 'vuex/dist/logger'
const store = new Vuex.Store({
  plugins: [logger()]
})
```

+ before fixing
```
import { createLogger } from "vuex";
const store = new Vuex.Store({
  plugins: [logger()]
})
```

+ after fixing
```
import { createLogger } from "vuex";
const store = new Vuex.Store({
  plugins: [createLogger()]
})
```
close #50 