### PR TITLE
feat: implement new-component-api transformation

### DIFF
--- a/transformations/__tests__/new-component-api.spec.ts
+++ b/transformations/__tests__/new-component-api.spec.ts
@@ -1,0 +1,17 @@
+import { defineInlineTest } from 'jscodeshift/src/testUtils'
+const transform = require('../new-component-api')
+
+defineInlineTest(
+  transform,
+  {},
+  `import Vue from 'vue'
+import MyComponent from './MyComponent'
+Vue.component('my-component', MyComponent)`,
+  `import MyComponent from './MyComponent'
+export default {
+  install: app => {
+    app.component('my-component', MyComponent);
+  }
+};;`,
+  'transform global component registration'
+)

--- a/transformations/__tests__/new-component-api.spec.ts
+++ b/transformations/__tests__/new-component-api.spec.ts
@@ -1,6 +1,8 @@
 import { defineInlineTest } from 'jscodeshift/src/testUtils'
 const transform = require('../new-component-api')
 
+global.globalApi= []
+
 defineInlineTest(
   transform,
   {},

--- a/transformations/index.ts
+++ b/transformations/index.ts
@@ -8,6 +8,7 @@ type JSTransformationModule = {
 const transformationMap: {
   [name: string]: JSTransformationModule
 } = {
+  'new-component-api': require('./new-component-api'),
   'vue-class-component-v8': require('./vue-class-component-v8'),
   'new-global-api': require('./new-global-api'),
   'vue-router-v4': require('./vue-router-v4'),
@@ -43,6 +44,7 @@ const transformationMap: {
 }
 
 export const excludedTransformations = [
+  'new-component-api',
   'define-component',
   'new-vue-to-create-app',
   'remove-contextual-h-from-render',

--- a/transformations/index.ts
+++ b/transformations/index.ts
@@ -44,7 +44,6 @@ const transformationMap: {
 }
 
 export const excludedTransformations = [
-  'new-component-api',
   'define-component',
   'new-vue-to-create-app',
   'remove-contextual-h-from-render',

--- a/transformations/new-component-api.ts
+++ b/transformations/new-component-api.ts
@@ -31,7 +31,10 @@ export const transformAST: ASTTransformation = context => {
       if (j.Identifier.check(componentArgs[1])) {
         componentApi = { name: componentArgs[1].name, path: filename }
       } else {
-        componentApi = { name: _.upperFirst(_.camelCase(componentArgs[0].value)), path: filename }
+        componentApi = {
+          name: _.upperFirst(_.camelCase(componentArgs[0].value)),
+          path: filename
+        }
       }
       global.globalApi.push(componentApi)
     }

--- a/transformations/new-component-api.ts
+++ b/transformations/new-component-api.ts
@@ -1,0 +1,66 @@
+import wrap from '../src/wrapAstTransformation'
+import type { ASTTransformation } from '../src/wrapAstTransformation'
+import { transformAST as removeExtraneousImport } from './remove-extraneous-import'
+import type { GlobalApi } from '../src/global'
+import * as _ from 'lodash'
+
+export const transformAST: ASTTransformation = context => {
+  const { root, j, filename } = context
+  // find Vue.component
+  const componentRegistration = root
+    .find(j.CallExpression, {
+      callee: {
+        type: 'MemberExpression',
+        object: {
+          name: 'Vue'
+        },
+        property: {
+          name: 'component'
+        }
+      }
+    })
+    .filter(path => {
+      return path.parent.parent.value.type === 'Program'
+    })
+
+  let componentArgs: any[] = []
+  componentRegistration.forEach(({ node }) => {
+    if (node.arguments.length === 2) {
+      componentArgs = node.arguments
+      let componentApi: GlobalApi
+      global.globalApi= []
+      if (j.Identifier.check(componentArgs[1])) {
+        componentApi = { name: componentArgs[1].name, path: filename }
+      } else {
+        componentApi = { name: _.upperFirst(_.camelCase(componentArgs[0].value)), path: filename }
+      }
+      global.globalApi.push(componentApi)
+    }
+  })
+
+  // app.component()
+  const componentCall = j.callExpression(
+    j.memberExpression(j.identifier('app'), j.identifier('component')),
+    componentArgs
+  )
+  // app => { app.component() }
+  const installArrowFunction = j.arrowFunctionExpression(
+    [j.identifier('app')],
+    j.blockStatement([j.expressionStatement(componentCall)])
+  )
+
+  // { install: app => {app.component() } }
+  const objectExpression = j.objectExpression([
+    j.objectProperty(j.identifier('install'), installArrowFunction)
+  ])
+
+  // export default {}
+  const exportDefaultDeclaration = j.exportDefaultDeclaration(objectExpression)
+
+  componentRegistration.replaceWith(() => exportDefaultDeclaration)
+
+  removeExtraneousImport(context, { localBinding: 'Vue' })
+}
+
+export default wrap(transformAST)
+export const parser = 'babylon'

--- a/transformations/new-component-api.ts
+++ b/transformations/new-component-api.ts
@@ -28,7 +28,6 @@ export const transformAST: ASTTransformation = context => {
     if (node.arguments.length === 2) {
       componentArgs = node.arguments
       let componentApi: GlobalApi
-      global.globalApi= []
       if (j.Identifier.check(componentArgs[1])) {
         componentApi = { name: componentArgs[1].name, path: filename }
       } else {

--- a/transformations/new-global-api.ts
+++ b/transformations/new-global-api.ts
@@ -3,6 +3,7 @@ import type { ASTTransformation } from '../src/wrapAstTransformation'
 
 import { transformAST as vueAsNamespaceImport } from './vue-as-namespace-import'
 import { transformAST as importCompositionApiFromVue } from './import-composition-api-from-vue'
+import { transformAST as newComponentApi } from './new-component-api'
 import { transformAST as newVueTocreateApp } from './new-vue-to-create-app'
 import { transformAST as rootPropToUse } from './root-prop-to-use'
 import { transformAST as removeTrivialRoot } from './remove-trivial-root'
@@ -15,6 +16,7 @@ import { transformAST as removeExtraneousImport } from './remove-extraneous-impo
 export const transformAST: ASTTransformation = context => {
   vueAsNamespaceImport(context)
   importCompositionApiFromVue(context)
+  newComponentApi(context)
   newVueTocreateApp(context)
   rootPropToUse(context, { rootPropName: 'store' })
   rootPropToUse(context, { rootPropName: 'router' })

--- a/transformations/new-global-api.ts
+++ b/transformations/new-global-api.ts
@@ -3,7 +3,6 @@ import type { ASTTransformation } from '../src/wrapAstTransformation'
 
 import { transformAST as vueAsNamespaceImport } from './vue-as-namespace-import'
 import { transformAST as importCompositionApiFromVue } from './import-composition-api-from-vue'
-import { transformAST as newComponentApi } from './new-component-api'
 import { transformAST as newVueTocreateApp } from './new-vue-to-create-app'
 import { transformAST as rootPropToUse } from './root-prop-to-use'
 import { transformAST as removeTrivialRoot } from './remove-trivial-root'
@@ -16,7 +15,6 @@ import { transformAST as removeExtraneousImport } from './remove-extraneous-impo
 export const transformAST: ASTTransformation = context => {
   vueAsNamespaceImport(context)
   importCompositionApiFromVue(context)
-  newComponentApi(context)
   newVueTocreateApp(context)
   rootPropToUse(context, { rootPropName: 'store' })
   rootPropToUse(context, { rootPropName: 'router' })


### PR DESCRIPTION
`Vue.component` global API will be transformed to plugin-use:
**in Vue 2**
```
// componnets/com/index.js
import Vue from 'vue'
import MyComp from './MyComp.vue'

Vue.component('my-comp', MyComp)
```
will be transformed to => 
**in Vue 3**
```
// main.js
import App from './App.vue'
import { Comp1 } from "../src/components/com/index.js";

createApp(App ).use(MyComp).mount('app')

// componnets/com/index.js
import MyComp from './MyComp.vue'

export default {
  install: app => {
    app.component("comp1", Comp1);
  }
};
```
