### PR TITLE
fix: don't remove Vue.use in other expression

### DIFF
--- a/transformations/__tests__/remove-vue-use.spec.ts
+++ b/transformations/__tests__/remove-vue-use.spec.ts
@@ -38,3 +38,13 @@ defineInlineTest(
   `app.use(router);`,
   `don't remove app.use`
 )
+
+defineInlineTest(
+  transform,
+  {
+    removablePlugins: ['VueRouter'],
+  },
+  `process.env.NODE_ENV === 'development' ? Vue.use(VueRouter) : null`,
+  `process.env.NODE_ENV === 'development' ? Vue.use(VueRouter) : null`,
+  `don't remove Vue.use in other expression`
+)

--- a/transformations/remove-vue-use.ts
+++ b/transformations/remove-vue-use.ts
@@ -33,17 +33,19 @@ export const transformAST: ASTTransformation<Params> = (
   })
 
   const removedPlugins: string[] = []
-  const removableUseCalls = vueUseCalls.filter(({ node }) => {
-    if (j.Identifier.check(node.arguments[0])) {
-      const plugin = node.arguments[0].name
-      if (removablePlugins?.includes(plugin)) {
-        removedPlugins.push(plugin)
-        return true
+  const removableUseCalls = vueUseCalls
+    .filter(path => path.parent.parent.value.type === 'Program')
+    .filter(({ node }) => {
+      if (j.Identifier.check(node.arguments[0])) {
+        const plugin = node.arguments[0].name
+        if (removablePlugins?.includes(plugin)) {
+          removedPlugins.push(plugin)
+          return true
+        }
       }
-    }
 
-    return false
-  })
+      return false
+    })
 
   removableUseCalls.remove()
 


### PR DESCRIPTION
we shouldn't remove `Vue.use` statement in other expression:
```
process.env.NODE_ENV === "development" ? Vue.use(VueI18n) : null;
```
or
```
if(process.env.NODE_ENV === "development"){
    Vue.use(Vuex) 
} 
```