### PR TITLE
fix: avoid conflicts between defined variables and imported specifier

### DIFF
--- a/transformations/__testfixtures__/vue-router-v4/rename-create-router.input.js
+++ b/transformations/__testfixtures__/vue-router-v4/rename-create-router.input.js
@@ -1,0 +1,24 @@
+import VueRouter from 'vue-router';
+import Home from '../views/Home.vue';
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    component: Home,
+  },
+  {
+    path: '/about',
+    name: 'about',
+    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
+  },
+];
+const createRouter = () => new VueRouter({
+  mode: 'history',
+  base: process.env.BASE_URL,
+  routes
+});
+
+const router = createRouter()
+
+export default router;

--- a/transformations/__testfixtures__/vue-router-v4/rename-create-router.output.js
+++ b/transformations/__testfixtures__/vue-router-v4/rename-create-router.output.js
@@ -1,0 +1,23 @@
+import { createRouter as newCreateRouter, createWebHistory } from 'vue-router';
+import Home from '../views/Home.vue';
+
+const routes = [
+  {
+    path: '/',
+    name: 'home',
+    component: Home,
+  },
+  {
+    path: '/about',
+    name: 'about',
+    component: () => import(/* webpackChunkName: "about" */ '../views/About.vue')
+  },
+];
+const createRouter = () => newCreateRouter({
+  history: createWebHistory(process.env.BASE_URL),
+  routes
+});
+
+const router = createRouter()
+
+export default router;

--- a/transformations/__tests__/vue-router-v4.spec.ts
+++ b/transformations/__tests__/vue-router-v4.spec.ts
@@ -3,9 +3,7 @@ jest.autoMockOff()
 import { defineTest } from 'jscodeshift/src/testUtils'
 
 defineTest(__dirname, 'vue-router-v4', {}, 'vue-router-v4/create-router')
-
 defineTest(__dirname, 'vue-router-v4', {}, 'vue-router-v4/create-history')
-
+defineTest(__dirname, 'vue-router-v4', {}, 'vue-router-v4/rename-create-router')
 defineTest(__dirname, 'router/router4-onready-to-isready', {}, 'vue-router-v4/router-ready')
-
 defineTest(__dirname, 'router/router-update-addRoute', {}, 'vue-router-v4/router-addRoute')

--- a/transformations/vue-router-v4.ts
+++ b/transformations/vue-router-v4.ts
@@ -26,10 +26,28 @@ export const transformAST: ASTTransformation = context => {
       }
     })
 
-    addImport(context, {
-      specifier: { type: 'named', imported: 'createRouter' },
-      source: 'vue-router'
+    let localCreateRouter = 'createRouter'
+    // find whether createRouter has been used
+    const createRouterIdentifiers = root.find(j.Identifier, {
+      name: 'createRouter'
     })
+    if (createRouterIdentifiers.length) {
+      // rename createRouter to newCreateRouter
+      localCreateRouter = 'newCreateRouter'
+      addImport(context, {
+        specifier: {
+          type: 'named',
+          imported: 'createRouter',
+          local: localCreateRouter
+        },
+        source: 'vue-router'
+      })
+    } else {
+      addImport(context, {
+        specifier: { type: 'named', imported: 'createRouter' },
+        source: 'vue-router'
+      })
+    }
     newVueRouter.replaceWith(({ node }) => {
       // mode: 'history' -> history: createWebHistory(), etc
       let historyMode = 'createWebHashHistory'
@@ -89,7 +107,7 @@ export const transformAST: ASTTransformation = context => {
         )
       )
 
-      return j.callExpression(j.identifier('createRouter'), node.arguments)
+      return j.callExpression(j.identifier(localCreateRouter), node.arguments)
     })
     removeExtraneousImport(context, {
       localBinding: localVueRouter


### PR DESCRIPTION
if the import specifier has been used in local file, then rename it:
```
import VueRouter from 'vue-router';

const createRouter = () => new VueRouter();
const router = createRouter()
```
=>
```
// rename createRouter to newCreateRouter 
import { createRouter as newCreateRouter } from 'vue-router';

const createRouter = () => newCreateRouter();
const router = createRouter()
```