### PR TITLE
fix: test will be failed when vue-transformation is in the new folder

### DIFF
--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -3,6 +3,8 @@ jest.autoMockOff()
 import * as fs from 'fs'
 import * as path from 'path'
 import runTransformation from './runTransformation'
+import transformationMap from '../transformations'
+import vueTransformationMap from '../vue-transformations'
 
 export const runTest = (
   description: string,
@@ -34,9 +36,9 @@ export const runTest = (
       path: inputPath,
       source: fs.readFileSync(inputPath).toString()
     }
-    const transformation = require((transformationType == 'vue'
-      ? '../vue-transformations'
-      : '../wrapAstTransformation') + `/${transformationName}`)
+    const transformation = (transformationType == 'vue'
+      ? vueTransformationMap
+      : transformationMap) [transformationName]
     expect(runTransformation(fileInfo, transformation)).toEqual(
       fs.readFileSync(outputPath).toString()
     )


### PR DESCRIPTION
before fix it, vue-transformation must be in the `../vue-transformations`,if not it will throw error because cant find the module,i want to create a new folder `element-ui` and put element-ui transformation in it