### PR TITLE
fix: add dependency `@babel/eslint-parser` during `package.json` conversion.

### DIFF
--- a/src/__tests__/packageTransformation.spec.ts
+++ b/src/__tests__/packageTransformation.spec.ts
@@ -57,6 +57,7 @@ let output =
 	},
 	"devDependencies": {
 		"@babel/core": "^7.14.6",
+		"@babel/eslint-parser": "^7.14.6",
 		"@vue/compiler-sfc": "^3.1.1",
 		"eslint": "^7.20.0",
 		"eslint-plugin-vue": "^7.11.1",

--- a/src/packageTransformation.ts
+++ b/src/packageTransformation.ts
@@ -34,6 +34,7 @@ const globalAddConfig: {
   devDependencies: {
     add: {
       '@babel/core': '^7.14.6',
+      '@babel/eslint-parser': '^7.14.6',
       eslint: '^7.20.0',
       '@vue/compiler-sfc': '^3.1.1',
       'eslint-plugin-vue': '^7.11.1'


### PR DESCRIPTION
Fix parsing error ` Cannot find module '@babel/eslint-parser'`